### PR TITLE
Favorite Workspace

### DIFF
--- a/domain/error/code.go
+++ b/domain/error/code.go
@@ -59,6 +59,7 @@ const (
 	ErrInvitationNoPerm           = 3064
 	ErrInvitationInvalidDate      = 3065
 	ErrGetScoreboard              = 3070
+	ErrWorkspaceUpdateFavorite    = 3080
 
 	ErrGradingRequest = 4000
 

--- a/domain/workspace.go
+++ b/domain/workspace.go
@@ -71,6 +71,7 @@ type WorkspaceRepository interface {
 	ListParticipant(workspaceId int) ([]WorkspaceParticipant, error)
 	UpdateRecent(userId string, workspaceId int) error
 	UpdateRole(userId string, workspaceId int, role WorkspaceRole) error
+	UpdateFavorite(userId string, workspaceId int, favorite bool) error
 }
 
 type WorkspaceUsecase interface {
@@ -88,4 +89,5 @@ type WorkspaceUsecase interface {
 	List(userId string) ([]Workspace, error)
 	ListParticipant(workspaceId int) ([]WorkspaceParticipant, error)
 	UpdateRole(updaterUserId string, targetUserId string, workspaceId int, role WorkspaceRole) error
+	UpdateFavorite(userId string, workspaceId int, favorite bool) error
 }

--- a/platform/server/controller/workspace.go
+++ b/platform/server/controller/workspace.go
@@ -163,3 +163,23 @@ func (c *WorkspaceController) JoinByInvitationCode(ctx *fiber.Ctx) error {
 
 	return response.NewSuccessResponse(ctx, fiber.StatusOK, nil)
 }
+
+func (c *WorkspaceController) UpdateFavorite(ctx *fiber.Ctx) error {
+	var pl payload.UpdateFavoritePayload
+	if ok, err := c.validator.Validate(&pl, ctx); !ok {
+		return err
+	}
+
+	user := middleware.GetUserFromCtx(ctx)
+
+	err := c.workspaceUsecase.UpdateFavorite(
+		user.Id,
+		pl.WorkspaceId,
+		pl.Favorite,
+	)
+	if err != nil {
+		return err
+	}
+
+	return response.NewSuccessResponse(ctx, fiber.StatusOK, nil)
+}

--- a/platform/server/fiber.go
+++ b/platform/server/fiber.go
@@ -130,6 +130,7 @@ func (s *FiberServer) applyRoutes() {
 	workspace.Get("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Get)
 	workspace.Get("/:workspaceId/participants", authMiddleware, workspaceMiddleware, workspaceController.ListParticipant)
 	workspace.Get("/:workspaceId/scoreboard", authMiddleware, workspaceMiddleware, workspaceController.GetScoreboard)
+	workspace.Post("/:workspaceId/favorite", authMiddleware, workspaceMiddleware, workspaceController.UpdateFavorite)
 
 	invitation := workspace.Group("/:workspaceId/invitation", middleware.PathType("invitation"))
 	invitation.Get("/", authMiddleware, workspaceMiddleware, workspaceController.GetInvitations)

--- a/platform/server/payload/workspace.go
+++ b/platform/server/payload/workspace.go
@@ -15,11 +15,11 @@ type AssignmentPath struct {
 
 type CreateInvitationPayload struct {
 	WorkspacePath
-	ValidAt    time.Time `form:"validAt" validate:"required"`
-	ValidUntil time.Time `form:"validUntil" validate:"required"`
+	ValidAt    time.Time `json:"validAt" validate:"required"`
+	ValidUntil time.Time `json:"validUntil" validate:"required"`
 }
 
 type UpdateFavoritePayload struct {
 	WorkspacePath
-	Favorite bool `form:"favorite"`
+	Favorite bool `json:"favorite"`
 }

--- a/platform/server/payload/workspace.go
+++ b/platform/server/payload/workspace.go
@@ -18,3 +18,8 @@ type CreateInvitationPayload struct {
 	ValidAt    time.Time `form:"validAt" validate:"required"`
 	ValidUntil time.Time `form:"validUntil" validate:"required"`
 }
+
+type UpdateFavoritePayload struct {
+	WorkspacePath
+	Favorite bool `form:"favorite" validate:"required"`
+}

--- a/platform/server/payload/workspace.go
+++ b/platform/server/payload/workspace.go
@@ -21,5 +21,5 @@ type CreateInvitationPayload struct {
 
 type UpdateFavoritePayload struct {
 	WorkspacePath
-	Favorite bool `form:"favorite" validate:"required"`
+	Favorite bool `form:"favorite"`
 }

--- a/platform/server/response/error.go
+++ b/platform/server/response/error.go
@@ -58,6 +58,7 @@ var DomainErrCodeToHttpStatus = map[int]int{
 	errs.ErrInvitationNoPerm:         fiber.StatusForbidden,
 	errs.ErrInvitationInvalidDate:    fiber.StatusBadRequest,
 	errs.ErrGetScoreboard:            fiber.StatusInternalServerError,
+	errs.ErrWorkspaceUpdateFavorite:  fiber.StatusInternalServerError,
 
 	errs.ErrGradingRequest: fiber.StatusInternalServerError,
 

--- a/repository/workspace.go
+++ b/repository/workspace.go
@@ -255,3 +255,18 @@ func (r *workspaceRepository) UpdateRole(
 	}
 	return nil
 }
+
+func (r *workspaceRepository) UpdateFavorite(
+	userId string,
+	workspaceId int,
+	favorite bool,
+) error {
+	_, err := r.db.Exec(
+		"UPDATE workspace_participant SET favorite = ? WHERE user_id = ? AND workspace_id = ?",
+		favorite, userId, workspaceId,
+	)
+	if err != nil {
+		return fmt.Errorf("cannot query to update favorite: %w", err)
+	}
+	return nil
+}

--- a/usecase/workspace.go
+++ b/usecase/workspace.go
@@ -246,3 +246,10 @@ func (u *workspaceUsecase) UpdateRole(
 	}
 	return nil
 }
+
+func (u *workspaceUsecase) UpdateFavorite(userId string, workspaceId int, favorite bool) error {
+	if err := u.workspaceRepository.UpdateFavorite(userId, workspaceId, favorite); err != nil {
+		return errs.New(errs.ErrWorkspaceUpdateFavorite, "cannot update favorite", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

### What
Briefly describe this feature / fix / refactor

- In brief, this branch has created the following features:
   - Add `favorite` endpoint: f570e83, 669a99c
   - Minor refactoring: aa23fc7

### Why
Describe the reason why we need this feature / fix / refactor

- While this feature is not that important, it does contribute significantly to improving the "quality of life" aspect of Codern.

### How
Describe the feature / fix / refactor in detail.

- Explain the technical solution you have done to create / fix this pull request
   - I've added POST endpoints for updating `favorite` fields. The change can be viewed in f570e83
   - Due to the payload validator being unable to pass payload if that payload's body include default value of specified data type (in this case, default of boolean is `false`), it causes problem upon POST-ing to update favorite to `false`. Thus, I avoid the limitation by removing `validate:"required"` from the payload struct's tag. This change can be viewed in 669a99c
   - According to convention, all tag that refer to body of payload is `json` and not `form`. In aa23fc7, I taken an initiative to change it.

- Attach the screenshot (if applicable)

![Screenshot 2566-12-16 at 01 03 59](https://github.com/codern-org/codern/assets/68505570/581e553d-20e0-4ed7-9771-01eb73f6de8f)
> Upon GET-ing workspace info in `/workspaces`, `favorite` field is still `false`.

![Screenshot 2566-12-16 at 01 04 17](https://github.com/codern-org/codern/assets/68505570/dc62786e-4ad6-495c-bfb7-9a60d25d5898)
> After POST-ing payload with `favorite` field in the body to `/workspaces/<workspaceId>/favorite`.

![Screenshot 2566-12-16 at 01 04 29](https://github.com/codern-org/codern/assets/68505570/5a1994ea-36f4-44ec-88a1-f934049816da)
> Finally, checking to see if `favorite` is updated to `true`.


### Todo list (if applicable)
- [x] Open my computer
- [x] Add `favorite` API endpoint
- [x] Make refactor where necessary

## Checklist
- [x] Drink juicy beverage when coding ☕️
- [x] Explained the purpose of this PR
- [x] Tested on **Local machine** and verified that there're no visible errors
- [ ] Tested on **Staging server** and verified that there're no visible errors
- [ ] Updated documentation (if applicable)
- [ ] Added or updated test suite for the changes (if applicable)
