### PR TITLE
Create + Delete Workspace

### DIFF
--- a/domain/error/code.go
+++ b/domain/error/code.go
@@ -47,9 +47,10 @@ const (
 	ErrGetRole                    = 30008
 	ErrListWorkspaceParticipant   = 30009
 	ErrGetScoreboard              = 30010
-	ErrUpdateWorkspace            = 30011
-	ErrCreateWorkspaceParticipant = 30012
-	ErrWorkspaceAlreadyJoin       = 30013
+	ErrCreateWorkspace            = 30011
+	ErrUpdateWorkspace            = 30012
+	ErrCreateWorkspaceParticipant = 30013
+	ErrWorkspaceAlreadyJoin       = 30014
 
 	ErrCreateInvitation      = 31000
 	ErrGetInvitation         = 31001

--- a/domain/error/code.go
+++ b/domain/error/code.go
@@ -49,8 +49,9 @@ const (
 	ErrGetScoreboard              = 30010
 	ErrCreateWorkspace            = 30011
 	ErrUpdateWorkspace            = 30012
-	ErrCreateWorkspaceParticipant = 30013
-	ErrWorkspaceAlreadyJoin       = 30014
+	ErrDeleteWorkspace            = 30013
+	ErrCreateWorkspaceParticipant = 30014
+	ErrWorkspaceAlreadyJoin       = 30015
 
 	ErrCreateInvitation      = 31000
 	ErrGetInvitation         = 31001

--- a/domain/workspace.go
+++ b/domain/workspace.go
@@ -15,6 +15,7 @@ type RawWorkspace struct {
 	ParticipantCount int       `json:"participantCount" db:"participant_count"`
 	TotalAssignment  int       `json:"totalAssignment" db:"total_assignment"`
 	IsOpenScoreboard bool      `json:"-" db:"is_open_scoreboard"`
+	IsDeleted        bool      `json:"-" db:"is_deleted"`
 }
 
 type Workspace struct {

--- a/domain/workspace.go
+++ b/domain/workspace.go
@@ -91,7 +91,7 @@ type WorkspaceRepository interface {
 	GetScoreboard(workspaceId int) ([]WorkspaceRank, error)
 	List(userId string) ([]Workspace, error)
 	ListParticipant(workspaceId int) ([]WorkspaceParticipant, error)
-	Update(workspace *Workspace) error
+	Update(userId string, workspace *Workspace) error
 	UpdateRecent(userId string, workspaceId int) error
 	UpdateRole(userId string, workspaceId int, role WorkspaceRole) error
 }

--- a/domain/workspace.go
+++ b/domain/workspace.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"io"
 	"time"
 )
 
@@ -26,8 +27,14 @@ type Workspace struct {
 	RecentlyVisitedAt   time.Time `json:"recentlyVisitedAt" db:"recently_visited_at"`
 }
 
+type CreateWorkspace struct {
+	Name    string `validate:"required"`
+	Profile io.Reader
+}
+
 type UpdateWorkspace struct {
 	Name     *string
+	Profile  io.Reader
 	Favorite *bool
 }
 
@@ -70,6 +77,7 @@ type WorkspaceRank struct {
 }
 
 type WorkspaceRepository interface {
+	Create(userId string, workspace *RawWorkspace) error
 	CreateInvitation(invitation *WorkspaceInvitation) error
 	GetInvitation(id string) (*WorkspaceInvitation, error)
 	GetInvitations(workspaceId int) ([]WorkspaceInvitation, error)
@@ -89,6 +97,7 @@ type WorkspaceRepository interface {
 }
 
 type WorkspaceUsecase interface {
+	Create(userId string, workspace *CreateWorkspace) (*RawWorkspace, error)
 	CreateInvitation(workspaceId int, inviterId string, validAt time.Time, validUntil time.Time) (string, error)
 	GetInvitation(id string) (*WorkspaceInvitation, error)
 	GetInvitations(workspaceId int) ([]WorkspaceInvitation, error)

--- a/domain/workspace.go
+++ b/domain/workspace.go
@@ -29,7 +29,7 @@ type Workspace struct {
 }
 
 type CreateWorkspace struct {
-	Name    string `validate:"required"`
+	Name    string
 	Profile io.Reader
 }
 

--- a/domain/workspace.go
+++ b/domain/workspace.go
@@ -113,6 +113,7 @@ type WorkspaceUsecase interface {
 	GetRole(userId string, workspaceId int) (*WorkspaceRole, error)
 	GetScoreboard(workspaceId int) ([]WorkspaceRank, error)
 	CheckPerm(userId string, workspaceId int) (bool, error)
+	CheckPermRole(userId string, workspaceId int, roles []WorkspaceRole) (bool, error)
 	List(userId string) ([]Workspace, error)
 	ListParticipant(workspaceId int) ([]WorkspaceParticipant, error)
 	Update(userId string, workspaceId int, workspace *UpdateWorkspace) error

--- a/domain/workspace.go
+++ b/domain/workspace.go
@@ -95,6 +95,7 @@ type WorkspaceRepository interface {
 	Update(userId string, workspace *Workspace) error
 	UpdateRecent(userId string, workspaceId int) error
 	UpdateRole(userId string, workspaceId int, role WorkspaceRole) error
+	Delete(workspaceId int) error
 }
 
 type WorkspaceUsecase interface {
@@ -116,4 +117,5 @@ type WorkspaceUsecase interface {
 	ListParticipant(workspaceId int) ([]WorkspaceParticipant, error)
 	Update(userId string, workspaceId int, workspace *UpdateWorkspace) error
 	UpdateRole(updaterUserId string, targetUserId string, workspaceId int, role WorkspaceRole) error
+	Delete(userId string, workspaceId int) error
 }

--- a/internal/constant/constant.go
+++ b/internal/constant/constant.go
@@ -18,4 +18,6 @@ var (
 	SeaweedFsChunkSize      = 1048576 // 1 MiB
 
 	MaxInvitationCodeChar = 6
+
+	DefaultProfileUrl = "/workspaces/1/profile"
 )

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func initUsecase(
 	sessionUsecase := usecase.NewSessionUsecase(cfg, repository.Session)
 	userUsecase := usecase.NewUserUsecase(platform.SeaweedFs, repository.User, sessionUsecase)
 	authUsecase := usecase.NewAuthUsecase(googleUsecase, sessionUsecase, userUsecase)
-	workspaceUsecase := usecase.NewWorkspaceUsecase(repository.Workspace, repository.User, userUsecase)
+	workspaceUsecase := usecase.NewWorkspaceUsecase(platform.SeaweedFs, repository.Workspace, repository.User, userUsecase)
 	assignmentUsecase := usecase.NewAssignmentUsecase(platform.SeaweedFs, repository.Assignment, publisher.Grading, workspaceUsecase)
 	surveyUsecase := usecase.NewSurveyUsecase(repository.Survey)
 

--- a/main.go
+++ b/main.go
@@ -157,7 +157,7 @@ func initUsecase(
 	sessionUsecase := usecase.NewSessionUsecase(cfg, repository.Session)
 	userUsecase := usecase.NewUserUsecase(platform.SeaweedFs, repository.User, sessionUsecase)
 	authUsecase := usecase.NewAuthUsecase(googleUsecase, sessionUsecase, userUsecase)
-	workspaceUsecase := usecase.NewWorkspaceUsecase(repository.Workspace, userUsecase)
+	workspaceUsecase := usecase.NewWorkspaceUsecase(repository.Workspace, repository.User, userUsecase)
 	assignmentUsecase := usecase.NewAssignmentUsecase(platform.SeaweedFs, repository.Assignment, publisher.Grading, workspaceUsecase)
 	surveyUsecase := usecase.NewSurveyUsecase(repository.Survey)
 

--- a/other/db/migrations/000009_add-delete-workspace.down.sql
+++ b/other/db/migrations/000009_add-delete-workspace.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `workspace`
+DROP `is_deleted`;

--- a/other/db/migrations/000009_add-delete-workspace.up.sql
+++ b/other/db/migrations/000009_add-delete-workspace.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `workspace`
+ADD `is_deleted` TINYINT(1) NOT NULL DEFAULT '0' AFTER `is_open_scoreboard`;

--- a/platform/server/controller/workspace.go
+++ b/platform/server/controller/workspace.go
@@ -215,3 +215,18 @@ func (c *WorkspaceController) Update(ctx *fiber.Ctx) error {
 
 	return response.NewSuccessResponse(ctx, fiber.StatusOK, nil)
 }
+
+func (c *WorkspaceController) Delete(ctx *fiber.Ctx) error {
+	var pl payload.WorkspacePath
+	if ok, err := c.validator.Validate(&pl, ctx); !ok {
+		return err
+	}
+
+	user := middleware.GetUserFromCtx(ctx)
+
+	if err := c.workspaceUsecase.Delete(user.Id, pl.WorkspaceId); err != nil {
+		return err
+	}
+
+	return response.NewSuccessResponse(ctx, fiber.StatusOK, nil)
+}

--- a/platform/server/controller/workspace.go
+++ b/platform/server/controller/workspace.go
@@ -207,6 +207,7 @@ func (c *WorkspaceController) Update(ctx *fiber.Ctx) error {
 		&domain.UpdateWorkspace{
 			Name:     pl.Name,
 			Favorite: pl.Favorite,
+			Profile:  pl.Profile,
 		},
 	); err != nil {
 		return err

--- a/platform/server/controller/workspace.go
+++ b/platform/server/controller/workspace.go
@@ -25,6 +25,28 @@ func NewWorkspaceController(
 	}
 }
 
+func (c *WorkspaceController) Create(ctx *fiber.Ctx) error {
+	var pl payload.CreateWorkspacePayload
+	if ok, err := c.validator.Validate(&pl, ctx); !ok {
+		return err
+	}
+
+	user := middleware.GetUserFromCtx(ctx)
+
+	workspace, err := c.workspaceUsecase.Create(
+		user.Id,
+		&domain.CreateWorkspace{
+			Name:    pl.Name,
+			Profile: pl.Profile,
+		},
+	)
+	if err != nil {
+		return err
+	}
+
+	return response.NewSuccessResponse(ctx, fiber.StatusOK, workspace)
+}
+
 // List godoc
 //
 // @Summary 		List workspaces

--- a/platform/server/fiber.go
+++ b/platform/server/fiber.go
@@ -129,9 +129,13 @@ func (s *FiberServer) applyRoutes() {
 	user.Patch("/", authMiddleware, userController.Update)
 	user.Patch("/password", authMiddleware, userController.UpdatePassword)
 
+	// TODO: Add delete workspace endpoint
 	workspace := api.Group("/workspaces", middleware.PathType("workspace"))
 	workspace.Get("/join/:invitationId", authMiddleware, workspaceController.JoinByInvitationCode)
 	workspace.Get("/", authMiddleware, workspaceMiddleware, workspaceController.List)
+	workspace.Post("/", authMiddleware, workspaceMiddleware, workspaceController.Create)
+	workspace.Patch("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Update)
+	// workspace.Delete("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Delete)
 	workspace.Get("/:workspaceId", publishableWorkspaceMiddleware, workspaceController.Get)
 	workspace.Patch("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Update)
 	workspace.Get("/:workspaceId/participants", authMiddleware, workspaceMiddleware, workspaceController.ListParticipant)

--- a/platform/server/fiber.go
+++ b/platform/server/fiber.go
@@ -135,7 +135,7 @@ func (s *FiberServer) applyRoutes() {
 	workspace.Get("/", authMiddleware, workspaceMiddleware, workspaceController.List)
 	workspace.Post("/", authMiddleware, workspaceMiddleware, workspaceController.Create)
 	workspace.Patch("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Update)
-	// workspace.Delete("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Delete)
+	workspace.Delete("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Delete)
 	workspace.Get("/:workspaceId", publishableWorkspaceMiddleware, workspaceController.Get)
 	workspace.Get("/:workspaceId/participants", authMiddleware, workspaceMiddleware, workspaceController.ListParticipant)
 	workspace.Get("/:workspaceId/scoreboard", scoreboardMiddleware, cache.New(), workspaceController.GetScoreboard)

--- a/platform/server/fiber.go
+++ b/platform/server/fiber.go
@@ -137,7 +137,6 @@ func (s *FiberServer) applyRoutes() {
 	workspace.Patch("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Update)
 	// workspace.Delete("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Delete)
 	workspace.Get("/:workspaceId", publishableWorkspaceMiddleware, workspaceController.Get)
-	workspace.Patch("/:workspaceId", authMiddleware, workspaceMiddleware, workspaceController.Update)
 	workspace.Get("/:workspaceId/participants", authMiddleware, workspaceMiddleware, workspaceController.ListParticipant)
 	workspace.Get("/:workspaceId/scoreboard", scoreboardMiddleware, cache.New(), workspaceController.GetScoreboard)
 

--- a/platform/server/payload/workspace.go
+++ b/platform/server/payload/workspace.go
@@ -34,5 +34,5 @@ type UpdateWorkspacePayload struct {
 	WorkspacePath
 	Name     *string `json:"name"`
 	Favorite *bool   `json:"favorite"`
-	Profile  *multipart.File
+	Profile  multipart.File
 }

--- a/platform/server/payload/workspace.go
+++ b/platform/server/payload/workspace.go
@@ -19,6 +19,13 @@ type CreateWorkspacePayload struct {
 	Profile multipart.File `file:"profile"`
 }
 
+type UpdateWorkspacePayload struct {
+	WorkspacePath
+	Name     *string        `json:"name"`
+	Favorite *bool          `json:"favorite"`
+	Profile  multipart.File `file:"profile"`
+}
+
 type CreateInvitationPayload struct {
 	WorkspacePath
 	ValidAt    time.Time `json:"validAt" validate:"required"`
@@ -28,11 +35,4 @@ type CreateInvitationPayload struct {
 type ListSubmissionPayload struct {
 	AssignmentPath
 	All bool `query:"all"`
-}
-
-type UpdateWorkspacePayload struct {
-	WorkspacePath
-	Name     *string        `json:"name"`
-	Favorite *bool          `json:"favorite"`
-	Profile  multipart.File `file:"profile"`
 }

--- a/platform/server/payload/workspace.go
+++ b/platform/server/payload/workspace.go
@@ -32,7 +32,7 @@ type ListSubmissionPayload struct {
 
 type UpdateWorkspacePayload struct {
 	WorkspacePath
-	Name     *string `json:"name"`
-	Favorite *bool   `json:"favorite"`
-	Profile  multipart.File
+	Name     *string        `json:"name"`
+	Favorite *bool          `json:"favorite"`
+	Profile  multipart.File `file:"profile"`
 }

--- a/platform/server/payload/workspace.go
+++ b/platform/server/payload/workspace.go
@@ -1,6 +1,7 @@
 package payload
 
 import (
+	"mime/multipart"
 	"time"
 )
 
@@ -11,6 +12,11 @@ type WorkspacePath struct {
 type AssignmentPath struct {
 	WorkspacePath
 	AssignmentId int `params:"assignmentId" validate:"required" json:"-"`
+}
+
+type CreateWorkspacePayload struct {
+	Name    string         `json:"name" validate:"required"`
+	Profile multipart.File `file:"profile"`
 }
 
 type CreateInvitationPayload struct {
@@ -28,4 +34,5 @@ type UpdateWorkspacePayload struct {
 	WorkspacePath
 	Name     *string `json:"name"`
 	Favorite *bool   `json:"favorite"`
+	Profile  *multipart.File
 }

--- a/repository/workspace.go
+++ b/repository/workspace.go
@@ -371,3 +371,13 @@ func (r *workspaceRepository) UpdateRole(
 	}
 	return nil
 }
+
+func (r *workspaceRepository) Delete(workspaceId int) error {
+	_, err := r.db.Exec(`
+		UPDATE workspace SET is_deleted = TRUE WHERE id = ?
+	`, workspaceId)
+	if err != nil {
+		return fmt.Errorf("cannot query to soft delete workspace: %w", err)
+	}
+	return nil
+}

--- a/repository/workspace.go
+++ b/repository/workspace.go
@@ -17,6 +17,26 @@ func NewWorkspaceRepository(db *sqlx.DB) domain.WorkspaceRepository {
 	return &workspaceRepository{db: db}
 }
 
+func (r *workspaceRepository) Create(userId string, workspace *domain.RawWorkspace) error {
+	_, err := r.db.NamedExec(`
+		INSERT INTO workspace (id, name, profile_url, created_at)
+		VALUES (:id, :name, :profile_url, :created_at)
+	`, workspace)
+	if err != nil {
+		return fmt.Errorf("cannot query to create workspace: %w", err)
+	}
+
+	_, err = r.db.Exec(`
+		INSERT INTO workspace_participant (workspace_id, user_id, role, favorite, joined_at, recently_visited_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+	`, workspace.Id, userId, domain.OwnerRole, false, time.Now(), time.Now())
+	if err != nil {
+		return fmt.Errorf("cannot query to insert owner into created workspace: %w", err)
+	}
+
+	return nil
+}
+
 func (r *workspaceRepository) CreateInvitation(invitation *domain.WorkspaceInvitation) error {
 	_, err := r.db.Exec(`
 		INSERT INTO workspace_invitation (id, workspace_id, inviter_id, created_at, valid_at, valid_until)

--- a/usecase/workspace.go
+++ b/usecase/workspace.go
@@ -314,7 +314,9 @@ func (u *workspaceUsecase) Update(userId string, workspaceId int, uw *domain.Upd
 		workspace.Favorite = *uw.Favorite
 	}
 
-	if err := u.workspaceRepository.Update(workspace); err != nil {
+	// TODO: Add code for uploading profile picture to seaweedfs
+
+	if err := u.workspaceRepository.Update(userId, workspace); err != nil {
 		return errs.New(errs.ErrUpdateWorkspace, "cannot update workspace id %d", workspaceId, err)
 	}
 

--- a/usecase/workspace.go
+++ b/usecase/workspace.go
@@ -354,3 +354,20 @@ func (u *workspaceUsecase) UpdateRole(
 	}
 	return nil
 }
+
+func (u *workspaceUsecase) Delete(userId string, workspaceId int) error {
+	isAuthorized, err := u.CheckPerm(userId, workspaceId)
+	if err != nil {
+		return errs.New(errs.SameCode, "cannot get workspace role while deleting workspace", err)
+	}
+
+	// TODO: Disallow admin from deleting workspace, only owners are allowed to delete workspace
+	if !isAuthorized {
+		return errs.New(errs.ErrWorkspaceNoPerm, "permission denied")
+	}
+
+	if err := u.workspaceRepository.Delete(workspaceId); err != nil {
+		return errs.New(errs.ErrDeleteWorkspace, "cannot delete workspace id %d", workspaceId, err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description

### What
Briefly describe this feature / fix / refactor

- In brief, this branch at API endpoints for creating and deleting workspaces for admins and owners.

### Why
Describe the reason why we need this feature / fix / refactor

- These features are included in stakeholders' defined requirements. Thus, it is a vital feature of Codern.

### How
Describe the feature / fix / refactor in detail.

- Explain the technical solution you have done to create / fix this pull request
   - In the df6bdd3, the `CREATE` endpoint are added. Using POST method to create a new workspace. As of now, noted that **anyone can create workspace**, since there're no function for checking permission in `Create()`.
   - In commit 1c0080f and 1a9a9fc, are fixes for the already implemented `UPDATE` API route. The codes are not in sync to the newer commits (esp. new `RawWorkspace` Struct in `domain`) so I took the opportunity to refactor and fix it.
   - 682f81e and ea5b735 are commits that involved adding `DELETE` **(soft delete)** route. This includes adding new column called `is_delete` to the database (can viewed in `db/migrations` folder).
   - In bcfcbe8, I added `CheckPermRole()` just to checking user's perms; however, it's different from `CheckPerm()`. In its parameter we can specified what role we want to check for. For example, if I want to check for just `OWNER` individually:
```go
isAuthorized, err := u.CheckPermRole(userId, workspaceId, []domain.WorkspaceRole{domain.OwnerRole})
```

- Attach the screenshot (if applicable)
   - If requested, I'll provide it in the comment sections 👍🏻

### Todo list (if applicable)
- [x] Open my computer
- [x] Add `CREATE` workspace API route
- [x] Add `DELETE` workspace API route
- [x] Add perms checking based on specified roles in parameters. 

## Checklist
- [x] Drink juicy beverage when coding ☕️
- [x] Explained the purpose of this PR
- [x] Tested on **Local machine** and verified that there're no visible errors
- [ ] Tested on **Staging server** and verified that there're no visible errors
- [ ] Updated documentation (if applicable)
- [ ] Added or updated test suite for the changes (if applicable)
