### PR TITLE
fix: parameters in the wrong order when delete duplicates session 

### DIFF
--- a/usecase/session.go
+++ b/usecase/session.go
@@ -60,7 +60,7 @@ func (u *sessionUsecase) Unsign(header string) (string, error) {
 func (u *sessionUsecase) Create(
 	userId string, ipAddress string, userAgent string,
 ) (*fiber.Cookie, error) {
-	if err := u.sessionRepository.DeleteDuplicates(userId, userAgent, ipAddress); err != nil {
+	if err := u.sessionRepository.DeleteDuplicates(userId, ipAddress, userAgent); err != nil {
 		return nil, errs.New(
 			errs.ErrDupSession,
 			"cannot delete previous session to create a new session for user id %d", userId,


### PR DESCRIPTION
variables were inserted in the wrong order in the delete duplicate session function

## Description

### What
The problem is that duplicate sessions are not deleted upon login.

### Why
Parameters in the wrong order when authUsecase call DeleteDuplicates from sessionRepository

### How
DeleteDuplicates Arrange parameters as (userId, ipAddress, userAgent)
But when called in authUsecase, arrange the parameters as (userId, userAgent, ipAddress)

- Just change the position of the parameters.

